### PR TITLE
feat: BREAKING use CONNECTOR_LEDGERS instead of CONNECTOR_CREDENTIALS

### DIFF
--- a/src/service-manager.js
+++ b/src/service-manager.js
@@ -119,7 +119,7 @@ class ServiceManager {
     this.connectors.push('http://localhost:' + port)
     return this._npm(['start'], 'connector:' + port, {
       env: Object.assign({}, COMMON_ENV, {
-        CONNECTOR_CREDENTIALS: JSON.stringify(options.credentials),
+        CONNECTOR_LEDGERS: JSON.stringify(options.credentials),
         CONNECTOR_PAIRS: JSON.stringify(options.pairs),
         CONNECTOR_MAX_HOLD_TIME: 600,
         CONNECTOR_ROUTE_BROADCAST_ENABLED: options.routeBroadcastEnabled === undefined || options.routeBroadcastEnabled,


### PR DESCRIPTION
tied to https://github.com/interledger/js-ilp-connector/pull/233 . There is no longer a `CONNECTOR_CREDENTIALS` field, only `CONNECTOR_LEDGERS`
