### PR TITLE
feat: allow user to override DEBUG env variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
     "byline": "^5.0.0",
     "chalk": "^1.1.3",
     "co": "^4.6.0",
-    "five-bells-shared": "^19.0.0",
+    "five-bells-shared": "^21.0.1",
     "sqlite": "^2.2.0",
-    "superagent": "^2.3.0",
+    "superagent": "^3.1.0",
     "supports-color": "^3.1.2",
     "through2": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^3.5.0",
     "eslint-config-standard": "^6.0.1",
-    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.0"
   }
 }

--- a/src/service-manager.js
+++ b/src/service-manager.js
@@ -13,8 +13,9 @@ const hashPassword = require('five-bells-shared/utils/hashPassword')
 const COMMON_ENV = Object.assign({}, {
   // Path is required for NPM to work properly
   PATH: process.env.PATH,
-  // Print additional debug information from Five Bells and ILP modules
-  DEBUG: 'five-bells-*,ilp-*'
+  // Print additional debug information from Five Bells and ILP modules, but
+  // allow the user to override this setting.
+  DEBUG: process.env.DEBUG || 'ledger*,connector*,notary*,five-bells*,ilp-*'
 }, !require('supports-color') ? {} : {
   // Force colored output
   FORCE_COLOR: 1,


### PR DESCRIPTION
Fixes the default behavior to print debug information from the ledger and connector (the tag had changed from `five-bells-ledger` to `ledger`) and allows users to override the setting.