### PR TITLE
feat: switches database for ledger and ILP kit from sqlite to postgres

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chalk": "^1.1.3",
     "co": "^4.6.0",
     "five-bells-shared": "^21.0.1",
-    "sqlite": "^2.2.0",
+    "pg-promise": "^5.6.4",
     "superagent": "^3.1.0",
     "supports-color": "^3.1.2",
     "through2": "^2.0.1"


### PR DESCRIPTION
By changing the database used during integration test from sqlite to postgres, our integration test environment resembles more closely production environments (sqlite is not supported in production).

Furthermore, sqlite does not support concurrent access from different processes to the same database and some of the queries performed by ILP kit fail if sqlite is used.