### PR TITLE
Refactor: use new ILP version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "pg-promise": "^5.6.4",
     "superagent": "^3.1.0",
     "supports-color": "^3.1.2",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "^3.5.0",


### PR DESCRIPTION
Change the code using the `ilp` module to use the API from https://github.com/interledgerjs/ilp/pull/79 . This will cause integration tests to fail between the time that it's merged and the ILP PR is merged, so it should not be merged until ILP #79 is ready.